### PR TITLE
changed to use the 6.14 & 6.13 versions of the babel package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "uglify-js": "2.4.24",
     "clean-css": "*",
     "babelify": "*",
-    "babel-preset-es2015": "*",
-    "babel-polyfill": "*"
+    "babel-preset-es2015": "6.14.0",
+    "babel-polyfill": "6.13.0"
   },
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
This is so that the new ES6 code does not prevent us from moving forward with this upgrade.
